### PR TITLE
Atualizar tema escuro com cores do ChatGPT

### DIFF
--- a/gpt-vault-hub-main/src/index.css
+++ b/gpt-vault-hub-main/src/index.css
@@ -80,42 +80,42 @@
   }
 
   .dark {
-    /* Dark theme ChatGPT inspired */
-    --background: 0 0% 8%;
-    --foreground: 0 0% 95%;
-    
-    --card: 0 0% 12%;
-    --card-foreground: 0 0% 95%;
-    
-    --popover: 0 0% 12%;
-    --popover-foreground: 0 0% 95%;
-    
-    --primary: 0 0% 100%;
-    --primary-foreground: 0 0% 0%;
-    --primary-hover: 0 0% 90%;
-    
-    --secondary: 0 0% 14%;
-    --secondary-foreground: 0 0% 95%;
-    --secondary-hover: 0 0% 16%;
-    
-    --muted: 0 0% 14%;
-    --muted-foreground: 0 0% 60%;
-    
-    --accent: 0 0% 14%;
-    --accent-foreground: 0 0% 95%;
-    
+    /* Dark theme matching ChatGPT */
+    --background: 235 11% 23%;
+    --foreground: 240 15% 94%;
+
+    --card: 235 11% 23%;
+    --card-foreground: 240 15% 94%;
+
+    --popover: 235 11% 23%;
+    --popover-foreground: 240 15% 94%;
+
+    --primary: 240 15% 94%;
+    --primary-foreground: 235 11% 23%;
+    --primary-hover: 233 9% 18%;
+
+    --secondary: 235 11% 23%;
+    --secondary-foreground: 240 15% 94%;
+    --secondary-hover: 233 9% 18%;
+
+    --muted: 235 11% 23%;
+    --muted-foreground: 240 5% 65%;
+
+    --accent: 235 11% 23%;
+    --accent-foreground: 240 15% 94%;
+
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
-    
-    --border: 0 0% 20%;
-    --input: 0 0% 14%;
-    --ring: 0 0% 100%;
-    
-    /* Dark chat colors */
-    --chat-bubble-user: 0 0% 100%;
-    --chat-bubble-assistant: 0 0% 14%;
-    --chat-input-bg: 0 0% 12%;
-    --sidebar-bg: 0 0% 10%;
+
+    --border: 236 11% 28%;
+    --input: 236 11% 28%;
+    --ring: 236 11% 28%;
+
+    /* Chat colors */
+    --chat-bubble-user: 235 10% 27%;
+    --chat-bubble-assistant: 233 11% 30%;
+    --chat-input-bg: 236 11% 28%;
+    --sidebar-bg: 220 5% 13%;
     
     /* Dark admin colors */
     --admin-accent: 217 91% 65%;
@@ -125,14 +125,14 @@
     --gradient-primary: linear-gradient(135deg, hsl(0 0% 100%), hsl(0 0% 90%));
     --gradient-admin: linear-gradient(135deg, hsl(217 91% 65%), hsl(217 91% 70%));
     
-    --sidebar-background: 0 0% 10%;
-    --sidebar-foreground: 0 0% 95%;
-    --sidebar-primary: 0 0% 100%;
-    --sidebar-primary-foreground: 0 0% 0%;
-    --sidebar-accent: 0 0% 14%;
-    --sidebar-accent-foreground: 0 0% 95%;
-    --sidebar-border: 0 0% 20%;
-    --sidebar-ring: 0 0% 100%;
+    --sidebar-background: 220 5% 13%;
+    --sidebar-foreground: 240 15% 94%;
+    --sidebar-primary: 240 15% 94%;
+    --sidebar-primary-foreground: 235 11% 23%;
+    --sidebar-accent: 236 11% 28%;
+    --sidebar-accent-foreground: 240 15% 94%;
+    --sidebar-border: 236 11% 28%;
+    --sidebar-ring: 236 11% 28%;
   }
 }
 


### PR DESCRIPTION
## Summary
- atualiza as variáveis CSS do tema `dark` para seguir as cores do ChatGPT

## Testing
- `npm run lint` *(falha: cannot find package '@eslint/js')*
- `npm run build` *(falha: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883048d62e0832cb1622713314e527f