### PR TITLE
Implement conversation history

### DIFF
--- a/gpt-vault-hub-main/src/components/MainLayout.tsx
+++ b/gpt-vault-hub-main/src/components/MainLayout.tsx
@@ -27,7 +27,13 @@ const MainLayout: React.FC = () => {
   const [activeTab, setActiveTab] = useState<ActiveTab>('chat');
   const { user, logout } = useAuth();
   const { theme, toggleTheme } = useTheme();
-  const { clearChat } = useChat();
+  const {
+    clearChat,
+    conversations,
+    activeConversationId,
+    startNewConversation,
+    selectConversation,
+  } = useChat();
 
   const handleLogout = () => {
     if (window.confirm('Tem certeza que deseja sair?')) {
@@ -119,7 +125,28 @@ const MainLayout: React.FC = () => {
 
           {/* Chat Actions */}
           {activeTab === 'chat' && (
-            <div className="mt-6 space-y-2">
+            <div className="mt-6 space-y-4">
+              <div className="space-y-1">
+                <h3 className="text-xs font-semibold text-muted-foreground mb-1">Histórico</h3>
+                {conversations.map((conv) => (
+                  <Button
+                    key={conv.id}
+                    variant={conv.id === activeConversationId ? 'secondary' : 'ghost'}
+                    className="w-full justify-start truncate"
+                    onClick={() => selectConversation(conv.id)}
+                  >
+                    {conv.title || 'Nova Conversa'}
+                  </Button>
+                ))}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={startNewConversation}
+              >
+                Nova Conversa
+              </Button>
               <Button
                 variant="outline"
                 size="sm"


### PR DESCRIPTION
## Summary
- persist chat history in ChatContext and restore it from localStorage
- expose history management helpers via ChatContext
- render conversation list in MainLayout sidebar with ability to start new conversations

## Testing
- `npm run lint` *(fails: eslint not found)*


------
https://chatgpt.com/codex/tasks/task_e_68831deb19ac832c8966ddf5d7fd3334