### PR TITLE
Add Supabase RLS setup docs

### DIFF
--- a/gpt-vault-hub-main/README.md
+++ b/gpt-vault-hub-main/README.md
@@ -180,6 +180,21 @@ CREATE TABLE files (
 );
 ```
 
+### 🔐 Políticas de RLS
+
+O script `supabase_policies.sql` contém um conjunto de políticas de segurança para
+garantir que os dados inseridos em `appointments`, `available_slots` e `profiles`
+respeitem as regras de acesso. Para aplicá-las, execute o arquivo no console SQL
+do Supabase:
+
+```bash
+psql $DB_URL -f supabase_policies.sql
+```
+
+Essas políticas permitem que qualquer usuário autenticado crie agendamentos,
+enquanto a gestão de horários disponíveis fica restrita a administradores
+(campo `is_admin` na tabela `profiles`).
+
 ## 🎯 Casos de Uso
 
 ### 👤 Usuário Comum

--- a/gpt-vault-hub-main/supabase_policies.sql
+++ b/gpt-vault-hub-main/supabase_policies.sql
@@ -1,0 +1,54 @@
+-- SQL setup for Supabase RLS and tables
+-- Add created_by field if not exists
+ALTER TABLE public.appointments
+ADD COLUMN IF NOT EXISTS created_by uuid DEFAULT auth.uid();
+
+ALTER TABLE public.available_slots
+ADD COLUMN IF NOT EXISTS created_by uuid DEFAULT auth.uid();
+
+ALTER TABLE public.appointments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.available_slots ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+-- Appointment policies
+CREATE POLICY "Allow insert for authenticated users"
+ON public.appointments
+FOR INSERT
+WITH CHECK (auth.uid() IS NOT NULL);
+
+CREATE POLICY "Select own appointments"
+ON public.appointments
+FOR SELECT
+USING (created_by = auth.uid());
+
+CREATE POLICY "Update/delete own appointments"
+ON public.appointments
+FOR UPDATE USING (created_by = auth.uid())
+WITH CHECK (created_by = auth.uid());
+
+-- Available slot policies for admins only
+CREATE POLICY "Admin manage available slots"
+ON public.available_slots
+FOR ALL
+USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.is_admin = TRUE))
+WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.is_admin = TRUE));
+
+-- Profile policies
+CREATE POLICY "Select own profile"
+ON public.profiles
+FOR SELECT
+USING (id = auth.uid());
+
+CREATE POLICY "Admin update profiles"
+ON public.profiles
+FOR UPDATE
+USING (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.is_admin = TRUE))
+WITH CHECK (EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid() AND p.is_admin = TRUE));


### PR DESCRIPTION
## Summary
- add `supabase_policies.sql` with recommended RLS policies
- document how to apply them in README

## Testing
- `npm run lint` *(fails: Cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68844cec25e4832cb9aaf57e1d078af3